### PR TITLE
1.0.3 Release

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk19

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                     <!-- WARNING: add release property for 1.9 and older versions -->
-<!--                    <release>${java.version}</release>-->
+                    <release>${java.version}</release>
                 </configuration>
             </plugin>
             <!-- endregion -->


### PR DESCRIPTION
### 1.0.3 Release - Jit java version hotfix.

- [Jitpack keeps showing a problem due to the Java version used](https://jitpack.io/com/github/WhiteOrganization/league-of-legends-role-identification/1.0.2/build.log), we are forcing Java 19, and this should be resolved now.
- `README.md` and `pom.xml` updated with the latest version and are ready for the release.