### PR TITLE
HighestWinRateForRole Functionality improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This library will help you to take an educated guess and calculate the rol/posit
 ## 1) What is this repository for?
 
 ### 1.1) Quick summary
-Version: `1.0.7`
+Version: `1.0.8`
 
 This library will help you to take an educated guess and calculate the rol/position/lane in which a champion will or should be in a 5v5 team of a League of Legends match.
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <!-- region Project configuration -->
     <groupId>org.white_sdev.white_gaming.lol</groupId>
     <artifactId>league-of-legends-role-identification</artifactId>
-    <version>1.0.7</version>
+    <version>1.0.8</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>This library will help you to take an educated guess and calculate the rol/position/lane in which a champion will or should be in a 5v5 team of a League of Legends match</description>
     <!--endregion-->


### PR DESCRIPTION
### HighestWinRateForRole Functionality improvement
`RoleIdentifier#getHighestWinRateForRole()` method was throwing an exception when criteria were not met, an improvement was introduced, and now there is another method that can be called with a flag that will return an `Optional.empty()` when this scenario occurs.
- `README.md` and `pom.xml` were updated with the latest version and are ready for the `release` process.